### PR TITLE
openからURI.openへ変更(Ruby3対応)

### DIFF
--- a/lib/firebase/auth/id_token_keeper/public_keys_endpoint.rb
+++ b/lib/firebase/auth/id_token_keeper/public_keys_endpoint.rb
@@ -38,7 +38,7 @@ module Firebase
         end
 
         def response
-          @response ||= open(PUBLIC_KEYS_URI)
+          @response ||= URI.open(PUBLIC_KEYS_URI)
         end
       end
     end


### PR DESCRIPTION
Ruby3から`Kernel#open`は削除され、`URI#open`を使用するよう変更になったため、Ruby3でも使えるように`URI#open`にコードを変更しました。

https://stackoverflow.com/questions/65937714/no-such-file-or-directory-rb-sysopen-for-external-url-rails-6-11-ruby-3
https://github.com/ruby/open-uri/commit/53862fa35887a34a8060aebf2241874240c2986a

